### PR TITLE
LFLT-357 Expired session is not dropped in LCFA

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-jwt-auth-support</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/front-end-support/pom.xml
+++ b/front-end-support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-jwt-auth-support</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/front-end-support/src/main/java/hu/psprog/leaflet/jwt/auth/support/logout/ForcedLogoutHandler.java
+++ b/front-end-support/src/main/java/hu/psprog/leaflet/jwt/auth/support/logout/ForcedLogoutHandler.java
@@ -1,0 +1,30 @@
+package hu.psprog.leaflet.jwt.auth.support.logout;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.stream.Stream;
+
+/**
+ * Helper component to handle forced-logout.
+ * Can be used to trigger "local" logout in case the backend has already invalidated the user's token.
+ *
+ * @author Peter Smith
+ */
+@Component
+public class ForcedLogoutHandler {
+
+    /**
+     * Forces logout by clearing security context, destroying the active session and all the cookies assigned to it.
+     *
+     * @param request {@link HttpServletRequest} object to access session and cookie data
+     */
+    public void forceLogout(HttpServletRequest request) {
+
+        SecurityContextHolder.clearContext();
+        request.getSession(false).invalidate();
+        Stream.of(request.getCookies())
+                .forEach(cookie -> cookie.setMaxAge(0));
+    }
+}

--- a/front-end-support/src/test/java/hu/psprog/leaflet/jwt/auth/support/logout/TokenRevokeLogoutHandlerTest.java
+++ b/front-end-support/src/test/java/hu/psprog/leaflet/jwt/auth/support/logout/TokenRevokeLogoutHandlerTest.java
@@ -1,8 +1,8 @@
 package hu.psprog.leaflet.jwt.auth.support.logout;
 
 import hu.psprog.leaflet.bridge.client.exception.CommunicationFailureException;
+import hu.psprog.leaflet.bridge.client.exception.UnauthorizedAccessException;
 import hu.psprog.leaflet.jwt.auth.support.exception.LogoutFailedException;
-import hu.psprog.leaflet.jwt.auth.support.exception.TokenAuthenticationFailureException;
 import hu.psprog.leaflet.jwt.auth.support.service.AuthenticationService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,6 +37,9 @@ public class TokenRevokeLogoutHandlerTest {
     @Mock
     private AuthenticationService authenticationService;
 
+    @Mock
+    private ForcedLogoutHandler forcedLogoutHandler;
+
     @InjectMocks
     private TokenRevokeLogoutHandler tokenRevokeLogoutHandler;
 
@@ -48,6 +51,20 @@ public class TokenRevokeLogoutHandlerTest {
 
         // then
         verify(authenticationService).revokeToken();
+    }
+
+    @Test
+    public void shouldCallForceLogoutInCaseUnauthorizedExceptionIsThrown() throws CommunicationFailureException {
+
+        // given
+        doThrow(UnauthorizedAccessException.class).when(authenticationService).revokeToken();
+
+        // when
+        tokenRevokeLogoutHandler.logout(request, response, authentication);
+
+        // then
+        verify(forcedLogoutHandler).forceLogout(request);
+        verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
     }
 
     @Test(expected = LogoutFailedException.class)

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-jwt-auth-support</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>hu.psprog.leaflet</groupId>
     <artifactId>leaflet-jwt-auth-support</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 
     <modules>
         <module>api</module>


### PR DESCRIPTION
 - Moved out force-logout logic to a separate component
 - Aligned ExpiredSessionFilter to call the new component
 - Aligned TokenRevokeLogoutHandler to handle already-invalidated scenario by forcing logout
 - Aligned tests, added new ones